### PR TITLE
Feat: 서버 에러 처리

### DIFF
--- a/src/app/_hooks/useReactQuery.tsx
+++ b/src/app/_hooks/useReactQuery.tsx
@@ -12,6 +12,8 @@ export default function ReactQueryProvider({
         defaultOptions: {
           queries: {
             staleTime: 60 * 1000,
+            throwOnError: true,
+            retry: 1,
           },
         },
       })

--- a/src/app/_utils/api.ts
+++ b/src/app/_utils/api.ts
@@ -12,7 +12,9 @@ const getContentsCount = async (searchParams: string) => {
   const data = await fetch(
     `${BASE_URL}/api/content/v1/contents-count?${searchParams}`
   );
-
+  if (!data.ok) {
+    throw new Error("API Error");
+  }
   return data.json();
 };
 
@@ -20,6 +22,9 @@ const getContents = async (page: number, searchParams: string) => {
   const data = await fetch(
     `${BASE_URL}/api/content/v1/contents?page=${page}&size=10&${searchParams}`
   );
+  if (!data.ok) {
+    throw new Error("API Error");
+  }
   return data.json();
 };
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import styles from "./not-found.module.css";
+import Link from "next/link";
+
+export default function Error({ error }: { error: Error }) {
+  useEffect(() => {
+    console.log(error);
+  }, []);
+  return (
+    <div className={styles.container}>
+      <div className={styles.contentBox}>
+        <h1 className={styles.text}>서버 에러가 발생했습니다. ㅠㅠ</h1>
+        <Link href="/" style={{ marginTop: 30 }}>
+          <h1 className={styles.linkText}>돌아가기</h1>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
fetch는 기본적으로 실패해도 에러를 던지지 않기 때문에 react-query가 에러를 잡지 못함.
따라서 throwOnError를 true로 설정해도 에러를 못잡음.

fetch에서 실패하면 에러를 던지도록 하고 그 에러를 리액트 쿼리가 다시 던지고 next에서 에러를 잡아서 최종적으로 처리